### PR TITLE
adding nil error handling

### DIFF
--- a/mixpanel.go
+++ b/mixpanel.go
@@ -245,16 +245,18 @@ func (m *mixpanel) sendPost(eventType string, params interface{}) error {
 	resp, err := http.Post(url, "application/json", responseBody)
 	//Handle Error
 	if err != nil {
-		wrapErr(&ErrTrackFailed{Body: err.Error(), Resp: resp})
+		return wrapErr(&ErrTrackFailed{Body: err.Error(), Resp: resp})
 	}
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	//Read the response body
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		wrapErr(&ErrTrackFailed{Body: err.Error(), Resp: resp})
+		return wrapErr(&ErrTrackFailed{Body: err.Error(), Resp: resp})
 	}
 	sb := string(body)
-	if sb != "1" {
+	if sb != "1" && sb != "1\n" {
 		return wrapErr(&ErrTrackFailed{Body: "response not 1", Resp: resp})
 	}
 


### PR DESCRIPTION
Also a test was failing when looking for "1" when it was returning "1\n", both should probably be accepted?  Not entirely sure. 

We were not returning errors from `sendPost` so any error that can cause an application crash is still be processed rather than returned and handled.  This probably exists elsewhere in this lib.